### PR TITLE
add support for Let's Encrypt DNS-01 challenge (for wildcard domains)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,6 +8,11 @@ LETS_ENCRYPT_EMAIL=certs@example.com
 # WARN, INFO etc.
 LOG_LEVEL=WARN
 
+## Enable dns challenge (for wildcard domains)
+##   https://doc.traefik.io/traefik/https/acme/#dnschallenge
+#LETS_ENCRYPT_DNS_CHALLENGE_ENABLED=1
+#LETS_ENCRYPT_DNS_CHALLENGE_PROVIDER=ovh
+
 ## Enable Keycloak
 #COMPOSE_FILE="compose.yml:compose.keycloak.yml"
 #KEYCLOAK_MIDDLEWARE_ENABLED=1

--- a/compose.yml
+++ b/compose.yml
@@ -21,6 +21,14 @@ services:
     environment:
       - DASHBOARD_ENABLED
       - LOG_LEVEL
+      {{ if eq (env "LETS_ENCRYPT_DNS_CHALLENGE_ENABLED") "1" }}
+      {{ if eq (env "LETS_ENCRYPT_DNS_CHALLENGE_PROVIDER") "ovh" }}
+      - OVH_APPLICATION_KEY
+      - OVH_APPLICATION_SECRET
+      - OVH_CONSUMER_KEY
+      - OVH_ENDPOINT
+      {{ end }}
+      {{ end }}
     healthcheck:
       test: ["CMD", "traefik", "healthcheck"]
       interval: 30s

--- a/traefik.yml.tmpl
+++ b/traefik.yml.tmpl
@@ -66,3 +66,7 @@ certificatesResolvers:
       storage: /etc/letsencrypt/production-acme.json
       httpChallenge:
         entryPoint: web
+        {{ if eq (env "LETS_ENCRYPT_DNS_CHALLENGE_ENABLED") "1" }}
+        dnsChallenge:
+          provider: {{ (env "LETS_ENCRYPT_DNS_CHALLENGE_PROVIDER") }}
+        {{ end }}


### PR DESCRIPTION
hi, first up thanks for all your work on Coop-Cloud, it's pretty cool! i was able to successfully deploy [butt.nz](https://butt.nz) using your `go-ssb-room`. :ok_person: 

however, this needs support for wildcard domains to handle user aliases (e.g. `cute.butt.nz`). 3wc was kind enough to merge a commit ( https://github.com/Autonomic-Cooperative/go-ssb-room/commit/9a7df0a5361b1c9a5642f7df9f5e5820ee66af4b ) to `go-ssb-room`, but here's a pull request to add the required support to `traefik`.

this change starts with support for OVH provider, but in a way for others to be added in the future: https://doc.traefik.io/traefik/https/acme/#dnschallenge

note: i haven't actually tested this, because i don't really understand how to deploy custom app versions, or how recipes work, or how versions are resolved in general. i'm currently running  a simpler change: https://github.com/ahdinosaur/coop-cloud-traefik/commit/972ed96c61993f124479b26f8ba15380f970e527, which i got deployed with some manual mucking about. any help on how to learn a development workflow for deploying unofficial versions would be much appreciated. :seedling: 

thanks! :smiley_cat: 